### PR TITLE
Add iteration details to the post-run report.

### DIFF
--- a/all.js
+++ b/all.js
@@ -36,8 +36,8 @@ const MAIN = async () => {
 						new Progression(Progression.TYPE_LINEAR, 1)));
 
 	AXES.push(new Axis(	Axis.TYPE_NEURONS,
-						2,		// boundsBegin
-						3,		// boundsEnd
+						3,//15,		// boundsBegin
+						5,//45,	// boundsEnd
 						new Progression(Progression.TYPE_FIBONACCI)));
 
 	const AXIS_SET = new AxisSet(AXES);

--- a/lib/Axis.js
+++ b/lib/Axis.js
@@ -62,11 +62,17 @@ class Axis {
 		this._progression.Reset();
 	}
 
-	WriteReport() {
+	WriteReport(compact) {
+		console.assert(typeof compact === 'boolean');
+
 		const REPORT_TEXT = this.CalculatePosition()
 							+ ' ' + this._typeName
-							+ ' { ' + this._boundBegin + ' - ' + this._boundEnd + ' '
-							+ this._progression.GetTypeName() + ' }';
+							+ (compact
+								? ''
+								: (' { ' + this._boundBegin
+									+ ' - '
+									+ this._boundEnd + ' '
+									+ this._progression.GetTypeName() + ' }'));
 
 		return REPORT_TEXT;
 	}

--- a/lib/AxisSet.js
+++ b/lib/AxisSet.js
@@ -75,10 +75,10 @@ class AxisSet {
 		this._axes.forEach(callback);
 	}
 
-	WriteAxisReport(index) {
+	WriteAxisReport(index, compact) {
 		this.ValidateIndex(index);
 
-		return this._axes[index].WriteReport();
+		return this._axes[index].WriteReport(compact);
 	}
 }
 

--- a/lib/AxisSetTraverser.js
+++ b/lib/AxisSetTraverser.js
@@ -13,6 +13,31 @@ class AxisSetTraverser {
 		this._totalAxes = this._axisSet.GetTotalAxes(); // cache this; it doesn't change
 
 		this._traversed = false;
+
+//NOTE: This function is buried in the c'tor because it actually runs the traversal (advances the axes).
+//		It cleans up after itself, resetting to a pristine state on the way out.
+		this._iterationDescriptorsByIndex = {};
+
+		const BUILD_SCHEDULE = () => {
+			let reportText = '';
+
+			for (let i = 0; !this.GetTraversed(); ++i) {
+				const DESCRIPTOR = this.WriteReport(true); // compact report
+
+				this._iterationDescriptorsByIndex[i] = DESCRIPTOR;
+
+				reportText += i + ': ' + DESCRIPTOR + '\n';
+
+				this.Advance();
+			}
+
+			console.log('Iteration schedule:' + '\n' + reportText);
+
+			// reset for traversals managed by the owner
+			this._traversed = false;
+		}
+
+		BUILD_SCHEDULE();
 	}
 
 	Advance() {
@@ -40,6 +65,8 @@ class AxisSetTraverser {
 
 		console.assert(resetCounter === this._totalAxes);
 
+		// this advance completed the traversal; reset
+
 		this._traversed = true;
 	}
 
@@ -51,15 +78,25 @@ class AxisSetTraverser {
 		return this._traversed;
 	}
 
-	WriteReport() {
+	LookupIterationDescriptor(i) {
+		console.assert(typeof i === 'number');
+
+		if (this._iterationDescriptorsByIndex[i] === undefined) {
+			throw new Error('Attempted to lookup descriptor for unknown iteration: ' + i);
+		}
+
+		return this._iterationDescriptorsByIndex[i];
+	}
+
+	WriteReport(compact) {
 		let reportText = '';
 
 		for (let i = 0; i < this._totalAxes; ++i) {
-			reportText += this._axisSet.WriteAxisReport(i) + '\n';
+			reportText += this._axisSet.WriteAxisReport(i, compact) + (compact ? ', ' : '\n');
 		}
 
-		// remove the trailing newline
-		reportText = reportText.slice(0, -1);
+		// remove the trailing newline or comma-and-space
+		reportText = reportText.slice(0, (compact ? -2 : -1));
 
 		return reportText;
 	}

--- a/lib/EpochStats.js
+++ b/lib/EpochStats.js
@@ -55,12 +55,12 @@ class EpochStats {
 			this._averageLoss.toFixed(REPORTING_DIGITS_STAT)
 			+ '(' + this._averageValidationLoss.toFixed(REPORTING_DIGITS_STAT) + ') '
 			+ 'Δ ' + (this._averageLossDelta < 0 ? '' : ' ' ) + this._averageLossDelta.toFixed(2) + ', '
-			+ 'm: ' + (this._lineLoss.m < 0 ? '' : ' ' ) + this._lineLoss.m.toFixed(REPORTING_DIGITS_SLOPE)
+			+ 'm ' + (this._lineLoss.m < 0 ? '' : ' ' ) + this._lineLoss.m.toFixed(REPORTING_DIGITS_SLOPE)
 			+ '(' + (this._lineValidationLoss.m < 0 ? '' : ' ' ) + this._lineValidationLoss.m.toFixed(REPORTING_DIGITS_SLOPE) + ') '
 			+ '|| '
 			+ this._averageAccuracy.toFixed(REPORTING_DIGITS_STAT)
 			+ '(' + this._averageValidationAccuracy.toFixed(REPORTING_DIGITS_STAT) + '), '
-			+ 'm: ' + (this._lineAccuracy.m < 0 ? '' : ' ' ) + this._lineAccuracy.m.toFixed(REPORTING_DIGITS_SLOPE)
+			+ 'm ' + (this._lineAccuracy.m < 0 ? '' : ' ' ) + this._lineAccuracy.m.toFixed(REPORTING_DIGITS_SLOPE)
 			+ '(' + (this._lineValidationAccuracy.m < 0 ? '' : ' ' ) + this._lineValidationAccuracy.m.toFixed(REPORTING_DIGITS_SLOPE) + ')';
 
 		return TEXT_OUT;

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -18,6 +18,7 @@ const { AxisSet }				= require('./AxisSet');
 const { AxisSetTraverser }		= require('./AxisSetTraverser');
 const { EpochStats }			= require('./EpochStats');
 const { GridRunStats }			= require('./GridRunStats');
+const { IterationResult }		= require('./IterationResult');
 const { ModelStatics }			= require('./ModelStatics');
 const { ModelTestStats }		= require('./ModelTestStats');
 const { SessionData }			= require('./SessionData');
@@ -178,7 +179,7 @@ class Grid {
 
 		for (let i = 0; !this._axisSetTraverser.GetTraversed(); ++i) {
 			console.log('________________________________________________________________');
-			console.log('Iteration ' + i + '\n' + this._axisSetTraverser.WriteReport());
+			console.log('Iteration ' + i + '\n' + this._axisSetTraverser.WriteReport(false)); // non-compact report
 
 			this._timeStartIteration = Date.now();
 
@@ -196,7 +197,12 @@ class Grid {
 
 			const MODEL_TEST_STATS = this.TestModel(MODEL, MODEL_PARAMS, Date.now() - this._timeStartIteration);
 
-			this._gridRunStats.AddIterationResult(i, MODEL_PARAMS, MODEL_TEST_STATS);
+			const ITERATION_RESULT = new IterationResult(	i,
+															this._axisSetTraverser.LookupIterationDescriptor(i),
+															MODEL_PARAMS,
+															MODEL_TEST_STATS);
+
+			this._gridRunStats.AddIterationResult(ITERATION_RESULT);
 
 			this._axisSetTraverser.Advance();
 		}
@@ -205,16 +211,27 @@ class Grid {
 
 		const GRID_DURATION = GRID_TIME_END - this._timeStartGrid;
 
-		console.log('\n',
-					'<< GRID SEARCH COMPLETE >>',
+		console.log('\n' + '<< GRID SEARCH COMPLETE >>',
 					'\n',
 					'\n' + 'started @ ' + (new Date(this._timeStartGrid)).toLocaleString(),
 					'\n' + '  ended @ ' + (new Date(GRID_TIME_END)).toLocaleString(),
 					'\n' + 'duration: ' + Utils.WriteDurationReport(GRID_DURATION),
 					'\n');
 
-//TODO: Write these results to a CSV file, maybe via prompt?
-//		The CSV text is ready. We just need the FileIO call.
+
+
+/*
+										//TODO: Write these results to a CSV file, maybe via prompt?
+											The CSV text is ready. We just need the FileIO call.
+											Also clear out your old branches locally, friend.
+											lots more params to support
+											multiple iterations and smart-start
+											Also write the friggin model/weight files (if we can get around that bug)
+											Then do a BASIC auto-abort on overfit
+											Then wut; ship? TS? Travis? NPM? JSDOC? Lots to do!
+*/
+
+
 
 		console.log('Results');
 		console.log(this._gridRunStats.WriteReport(true));

--- a/lib/GridRunStats.js
+++ b/lib/GridRunStats.js
@@ -1,6 +1,7 @@
 'use strict';
 
 
+const { IterationResult } = require('./IterationResult');
 const { ModelTestStats } = require('./ModelTestStats');
 
 
@@ -9,20 +10,10 @@ class GridRunStats {
 		this._iterationResults = [];
 	}
 
-	AddIterationResult(id, modelParams, modelTestStats) {
-		console.assert(typeof id === 'number');
-		console.assert(id >= 0);
-		console.assert(Math.floor(id) === id);
-		console.assert(typeof modelParams === 'object');
-		console.assert(modelTestStats instanceof ModelTestStats);
+	AddIterationResult(iterationResult) {
+		console.assert(iterationResult instanceof IterationResult);
 
-//TODO: Consider lifting this into a class; ...how it's used is still very TBD.
-		this._iterationResults.push({
-										id: id,
-										modelParams: modelParams,
-										modelTestStats: modelTestStats,
-										score: modelTestStats.CalculateScore()
-									});
+		this._iterationResults.push(iterationResult);
 	}
 
 	WriteCSV() {
@@ -36,7 +27,7 @@ class GridRunStats {
 
 //TODO: Consider writing the full ModelTestStats details into this CSV dump.
 
-		const MODEL_PARAMS_EXAMPLE = this._iterationResults[0].modelParams;
+		const MODEL_PARAMS_EXAMPLE = this._iterationResults[0]._modelParams;
 
 		for (let k in MODEL_PARAMS_EXAMPLE) {
 			headerText += k + ',';
@@ -84,7 +75,7 @@ class GridRunStats {
 		let outgoingText = '';
 
 		iterations.forEach((value, index) => {
-			outgoingText += 'Iteration: ' + index + ', Score: ' + (100 * value.score).toFixed(1) + '%' + '\n';
+			outgoingText += value.WriteReport() + '\n';
 		});
 
 		// drop the trailing newline
@@ -92,12 +83,6 @@ class GridRunStats {
 
 		return outgoingText;
 	}
-}
-
-
-//doom ... maybe
-GridRunStats.WriteIterationDescriptor = (modelParams) => {
-
 }
 
 

--- a/lib/IterationResult.js
+++ b/lib/IterationResult.js
@@ -1,0 +1,37 @@
+'use strict';
+
+
+const { ModelTestStats } = require("./ModelTestStats");
+
+
+class IterationResult {
+	constructor(id, descriptor, modelParams, modelTestStats) {
+		console.assert(typeof id === 'number');
+		console.assert(id >= 0);
+		console.assert(typeof descriptor === 'string');
+		console.assert(descriptor !== '');
+		console.assert(Math.floor(id) === id);
+		console.assert(typeof modelParams === 'object');
+		console.assert(modelTestStats instanceof ModelTestStats);
+
+		this._id = id;
+		this._descriptor = descriptor;
+		this._modelParams = modelParams;
+		this._modelTestStats = modelTestStats;
+
+		this._score = this._modelTestStats.CalculateScore();
+	}
+
+	get score() { return this._score; }
+
+	WriteReport() {
+		return 'Iteration: ' + this._id + ', '
+				+ 'Score: ' + (100 * this._score).toFixed(1) + '%, '
+				+ 'Dynamics: ' + this._descriptor;
+	}
+}
+
+
+Object.freeze(IterationResult);
+
+exports.IterationResult = IterationResult;

--- a/lib/ModelStatics.js
+++ b/lib/ModelStatics.js
@@ -51,11 +51,13 @@ class ModelStatics {
 		this._staticParams.dropoutEnabled1stHidden = false; // would be input layer, but for built-in inputs ><
 		this._staticParams.dropoutEnabled2ndHidden = false;
 		this._staticParams.dropoutRate = 0.05;
-		this._staticParams.totalCases = 100 * 1000; // this should come from the data
-		this._staticParams.batchSize = 1;
+
+// i think this can go, since we pass in the data ... right?
+//		this._staticParams.totalCases = 100 * 1000; // this should come from the data
+		this._staticParams.batchSize = 10;
 		this._staticParams.validationSplit = 0.25; // this % is not trained upon by fit()
 		// this._staticParams.adamLearnRate = 0.001;
-		this._staticParams.epochs = 5;
+		this._staticParams.epochs = 50;
 		this._staticParams.standardizeInput = true; // to mean zero, variance one
 
 		// axes to be supported, eventually


### PR DESCRIPTION
- Create IterationResult to manage the params and score of a grid step.
This is built from code factored out of GridRunStats.
- Add iteration descriptor, which prints the dynamic params. This gives
the entire Axis WriteReport() lineage a compact-mode boolean.
The descriptors are written by pre-running AxisSetTraverser upon
instantiation.