### PR TITLE
Add float support for Axes

### DIFF
--- a/all.js
+++ b/all.js
@@ -50,32 +50,30 @@ const MAIN = async () => {
 
 	const AXES = [];
 
-	AXES.push(new Axis(	Axis.TYPE_BATCH_SIZE,
-						1,		// boundsBegin
-						20,		// boundsEnd
-						new Progression(Progression.TYPE_LINEAR, 3)));
+	// AXES.push(new Axis(	Axis.TYPE_BATCH_SIZE,
+	// 					1,		// boundsBegin
+	// 					20,		// boundsEnd
+	// 					new Progression(Progression.TYPE_LINEAR, 3, null, true)));
 
 	// AXES.push(new Axis(	Axis.TYPE_EPOCHS,
 	// 					10,		// boundsBegin
 	// 					20,		// boundsEnd
-	// 					new Progression(Progression.TYPE_LINEAR, 5)));
+	// 					new Progression(Progression.TYPE_LINEAR, 5, null, true)));
 
 	// AXES.push(new Axis(	Axis.TYPE_LAYERS,
 	// 					1,		// boundsBegin
 	// 					2,		// boundsEnd
-	// 					new Progression(Progression.TYPE_LINEAR, 1)));
+	// 					new Progression(Progression.TYPE_LINEAR, 1, null, true)));
 
-	// AXES.push(new Axis(	Axis.TYPE_NEURONS,
-	// 					10,		// boundsBegin
-	// 					20,		// boundsEnd
-	// 					new Progression(Progression.TYPE_LINEAR, 1)));
+	AXES.push(new Axis(	Axis.TYPE_NEURONS,
+						10,		// boundsBegin
+						20,		// boundsEnd
+						new Progression(Progression.TYPE_LINEAR, 1, null, true)));
 
-/*SOON
-	AXES.push(new Axis(	Axis.TYPE_VALIDATION_SPLIT,
-						0.2,		// boundsBegin
-						0.8,		// boundsEnd
-						new Progression(Progression.TYPE_EXPONENTIAL, 2)));
-*/
+	// AXES.push(new Axis(	Axis.TYPE_VALIDATION_SPLIT,
+	// 					0.1,		// boundsBegin
+	// 					0.3,		// boundsEnd
+	// 					new Progression(Progression.TYPE_LINEAR, 0.05, null, false)));
 
 	const AXIS_SET = new AxisSet(AXES);
 

--- a/lib/Axis.js
+++ b/lib/Axis.js
@@ -65,7 +65,11 @@ class Axis {
 	WriteReport(compact) {
 		console.assert(typeof compact === 'boolean');
 
-		const REPORT_TEXT = this.CalculatePosition()
+		const POSITION_TEXT = this._progression.clampToInt
+								? this.CalculatePosition()
+								: this.CalculatePosition().toFixed(3);
+
+		const REPORT_TEXT = POSITION_TEXT
 							+ ' ' + this._typeName
 							+ (compact
 								? ''

--- a/lib/Progression.js
+++ b/lib/Progression.js
@@ -2,9 +2,12 @@
 
 
 class Progression {
-	constructor(typeEnum, base, modifier) {
+	constructor(typeEnum, base, modifier, clampToInt) {
 		console.assert(typeof typeEnum === 'number');
 		console.assert(typeEnum >= 0 && typeEnum < Progression.TOTAL_TYPES);
+		console.assert(typeof clampToInt === 'boolean');
+
+		this._clampToInt = clampToInt;
 
 		switch (typeEnum) {
 			case Progression.TYPE_EXPONENTIAL: {
@@ -58,7 +61,12 @@ class Progression {
 					console.warn('linear progression does not use a modifier; ignored');
 				}
 
-				console.assert(base >= 1);
+				if (this._clampToInt) {
+					console.assert(base >= 1);
+				}
+				else {
+					console.assert(base > 0);
+				}
 
 				// Examples of _LINEAR:
 				//
@@ -83,6 +91,8 @@ class Progression {
 //NOTE: This call initializes _base, _modifier and _value.
 		this.Reset();
 	}
+
+	get clampToInt() { return this._clampToInt; }
 
 	Advance() {
 		switch (this._typeEnum) {
@@ -125,7 +135,7 @@ class Progression {
 	}
 
 	GetValue() {
-		return Math.floor(this._value);
+		return this._clampToInt ? Math.floor(this._value) : this._value;
 	}
 
 	Reset() {


### PR DESCRIPTION
- Give Progressions a clampToInt ctor param.
- Customize the report writer in Axis to use fixed digits on floats

NOTE: This pass revealed Progressions need a rewrite; this float stuff
isn't robust enough, and there are clearly issues w/ the values (not
wrong, just not what the user expects).