### PR TITLE
Refactor validation and validate axis bounds

### DIFF
--- a/all.js
+++ b/all.js
@@ -43,19 +43,16 @@ const MAIN = async () => {
 
 	const AXES = [];
 
-/*
 	AXES.push(new Axis(	Axis.TYPE_BATCH_SIZE,
-						1,		// boundsBegin
-						50,		// boundsEnd
-						new ExponentialProgression(1.5, 0.5)));
-*/
+						100,	// boundsBegin
+						10,		// boundsEnd
+						new ExponentialProgression(4, 1)));
 
 	AXES.push(new Axis(	Axis.TYPE_EPOCHS,
 						10,		// boundsBegin
 						20,		// boundsEnd
 						new FibonacciProgression(4)));
 
-/*
 	AXES.push(new Axis(	Axis.TYPE_LAYERS,
 						0,		// boundsBegin
 						1,		// boundsEnd
@@ -64,13 +61,13 @@ const MAIN = async () => {
 	AXES.push(new Axis(	Axis.TYPE_NEURONS,
 						10,		// boundsBegin
 						20,		// boundsEnd
-						new Progression(Progression.TYPE_LINEAR, 5, null, true)));
+						new LinearProgression(5)));
 
 	AXES.push(new Axis(	Axis.TYPE_VALIDATION_SPLIT,
 						0.1,		// boundsBegin
-						0.4,		// boundsEnd
-						new Progression(Progression.TYPE_LINEAR, 0.15, null, false)));
-*/
+						0.8,		// boundsEnd
+						new ExponentialProgression(1.5, 0.25)));
+
 
 	const AXIS_SET = new AxisSet(AXES);
 
@@ -83,9 +80,8 @@ const MAIN = async () => {
 //		The user supplies a callback. We invoke the callback each iteration, passing the current value for each
 //		dynamic param (i.e. those with axes). The user then assembles and returns a model.
 
-	const MODEL_STATICS = new ModelStatics(	//AXIS_SET,
-											{
-												// batchSize: 10,
+	const MODEL_STATICS = new ModelStatics(	{
+												batchSize: 10,
 												// epochs: 10,
 												hiddenLayers: 1,
 												neuronsPerHiddenLayer: 15,

--- a/lib/Axis.js
+++ b/lib/Axis.js
@@ -2,6 +2,7 @@
 
 
 const { Progression } = require('./Progression');
+const { Utils } = require('./Utils');
 
 
 class Axis {
@@ -24,7 +25,37 @@ class Axis {
 
 		this._typeName = Axis.LookupTypeName(this._typeEnum);
 
+//NOTE: Validate these bounds. Invalid input is fatal, so that users don't kick off (potentially very
+//		long) grid searches with a doomed model config. It may not fail until the end.
+//		Imagine this case:
+//			- batchSize 100 - 0, stepped by 2
+//			- plus several other axes; 1000+ combinations with say 3x repetitions
+//
+//		Batch size zero is invalid, and will crash TF. However, the user wouldn't find out until the grid
+//		search was near its end, after hours (or days!).
+//		This will nip that in the bud.
+//
+//		That said - we only enforce basic rules, e.g. no negative epoch counts, integer neuron counts, etc...
+//		We're not attempting to do TF's job, here.
+//		Nor can we project memory usage and battery life (yet).
+
+		const VALIDATION_ERROR = {message: ''};
+
+		if (!Axis.AttemptValidateParameter(this._typeName, this._boundBegin, VALIDATION_ERROR)) {
+			throw new Error('There was a problem with an axis-begin value. ' + VALIDATION_ERROR.message);
+		}
+
+		if (!Axis.AttemptValidateParameter(this._typeName, this._boundEnd, VALIDATION_ERROR)) {
+			throw new Error('There was a problem with an axis-end value. ' + VALIDATION_ERROR.message);
+		}
+
+		if (!Axis.AttemptValidateProgression(this._typeName, this._progression, VALIDATION_ERROR)) {
+			throw new Error('There was a problem with an axis progression. ' + VALIDATION_ERROR.message);
+		}
+
 		const BOUNDS_DELTA = this._boundEnd - this._boundBegin;
+
+//NOTE: Negative deltas are supported.
 
 		if (BOUNDS_DELTA === 0) {
 			console.warn('"' + this._typeName
@@ -77,6 +108,7 @@ class Axis {
 	}
 }
 
+
 let enumKey = 0;
 
 //TODO: (low-pri) Lift all of these out into a config file, so users can define their own model environments.
@@ -125,6 +157,100 @@ Axis.LookupTypeName = (x) => {
 			throw new Error('invalid enum index: ' + x + '/' + Axis.TOTAL_TYPES);
 		}
 	}
+};
+
+
+const ERROR_TEXT_EXCLUSIVE_UNIT_SCALAR	= 'The value must be between 0 and 1 exclusive.';
+const ERROR_TEXT_NON_NEGATIVE_INTEGER	= 'The value must be a non-negative integer.';
+const ERROR_TEXT_PARAM_UNKNOWN			= 'The parameter is not recognized.';
+const ERROR_TEXT_POSITIVE_INTEGER		= 'The value must be a positive integer.';
+
+
+Axis.AttemptValidateParameter = (key, value, errorData) => {
+	console.assert(typeof errorData === 'object');
+	console.assert(errorData.message !== undefined);
+
+//NOTE: It's important to gracefully handle bad inputs here, with explanations and recommendations in the failure text.
+//		This has the potential to be a point-of-failure for new users ramping up on model config.
+
+	let errorSuffix = '';
+
+	switch (key) {
+		case Axis.TYPE_NAME_BATCH_SIZE:
+		case Axis.TYPE_NAME_EPOCHS:
+		case Axis.TYPE_NAME_NEURONS: {
+			if (Utils.CheckPositiveInteger(value)) {
+				return true;
+			}
+
+			errorSuffix = ERROR_TEXT_POSITIVE_INTEGER;
+		}
+		break;
+
+		case Axis.TYPE_NAME_LAYERS: {
+			if (Utils.CheckNonNegativeInteger(value)) { // zero is allowed
+				return true;
+			}
+
+			errorSuffix = ERROR_TEXT_NON_NEGATIVE_INTEGER;
+		}
+		break;
+
+		case Axis.TYPE_NAME_VALIDATION_SPLIT: {
+			if (Utils.CheckFloat0to1Exclusive(value)) { // zero and one are not allowed; they disable TF validation
+				return true;
+			}
+
+			errorSuffix = ERROR_TEXT_EXCLUSIVE_UNIT_SCALAR;
+		}
+		break;
+
+		default: {
+			errorSuffix = ERROR_TEXT_PARAM_UNKNOWN;
+		}
+	}
+
+	errorData.message = '"' + key + '" is not valid. ' + errorSuffix;
+
+	return false;
+};
+
+Axis.AttemptValidateProgression = (key, progression, errorData) => {
+	console.assert(typeof errorData === 'object');
+	console.assert(errorData.message !== undefined);
+
+//NOTE: It's important to gracefully handle bad inputs here, with explanations and recommendations in the failure text.
+//		This has the potential to be a point-of-failure for new users ramping up on model config.
+
+	let errorSuffix = '';
+
+	switch (key) {
+		// integer progressions, only
+		case Axis.TYPE_NAME_BATCH_SIZE:
+		case Axis.TYPE_NAME_EPOCHS:
+		case Axis.TYPE_NAME_NEURONS:
+		case Axis.TYPE_NAME_LAYERS: {
+			if (progression.integerBased) {
+				return true;
+			}
+
+			errorSuffix = ERROR_TEXT_POSITIVE_INTEGER;
+		}
+		break;
+
+		// floating-point progressions allowed
+		case Axis.TYPE_NAME_VALIDATION_SPLIT: {
+			return true;
+		}
+
+		default: {
+			errorSuffix = ERROR_TEXT_PARAM_UNKNOWN;
+		}
+	}
+
+	errorData.message = '"' + key + '" is not valid. ' + errorSuffix;
+
+	return false;
 };
 
 

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -83,22 +83,6 @@ class Grid {
 
 		// prune (and warn about) any model params that are pre-empted by a dynamic axis
 		this.ResolveModelDefinition();
-
-/*
-/-NOTE: IMPORTANT:
-
-!! We need to validate the bounds of each axis (to the extent we validate; not attempting to do TF's job, here).
-!! Imagine this case:
-!!    batchSize 20 - 0
-!!	  (plus several other axes)
-!!
-!! Batch size zero is invalid, and will crash TF. However, the user wouldn't find out until the grid walk  was near its end,
-!! after potentially a very long time; could have nipped that in the bud.
-!! Use AttemptValidateParameter, just as above. Find the right way to abstract that piece.
-
--/
-*/
-
 	}
 
 	CreateModel(modelParams) {

--- a/lib/ModelStatics.js
+++ b/lib/ModelStatics.js
@@ -4,8 +4,7 @@
 const TENSOR_FLOW = require('@tensorflow/tfjs');
 
 
-const { Axis }		= require('./Axis');
-const { Utils }		= require('./Utils');
+const { Axis } = require('./Axis');
 
 
 class ModelStatics {
@@ -18,9 +17,9 @@ class ModelStatics {
 		const VALIDATION_ERROR = {message: ''};
 
 		for (let k in params) {
-			if (!ModelStatics.AttemptValidateParameter(k, params[k], VALIDATION_ERROR)) {
+			if (!Axis.AttemptValidateParameter(k, params[k], VALIDATION_ERROR)) {
 				// fatal, so that users don't kick off a (potentially very long) grid search with a bad model config
-				throw new Error('There was a problem with the model params.' + '\n' + VALIDATION_ERROR.message);
+				throw new Error('There was a problem with the static model params. ' + VALIDATION_ERROR.message);
 			}
 		}
 //^^
@@ -85,25 +84,30 @@ class ModelStatics {
 
 		// set the user's value, or take the program default (every param is optional)
 
-		this._staticParams[Axis.TYPE_NAME_BATCH_SIZE] = params[Axis.TYPE_NAME_BATCH_SIZE] !== undefined
-														? params[Axis.TYPE_NAME_BATCH_SIZE]
-														: Axis.TYPE_DEFAULT_BATCH_SIZE;
+		this._staticParams[Axis.TYPE_NAME_BATCH_SIZE] =
+			params[Axis.TYPE_NAME_BATCH_SIZE] !== undefined
+			? params[Axis.TYPE_NAME_BATCH_SIZE]
+			: Axis.TYPE_DEFAULT_BATCH_SIZE;
 
-		this._staticParams[Axis.TYPE_NAME_EPOCHS] = params[Axis.TYPE_NAME_EPOCHS] !== undefined
-													? params[Axis.TYPE_NAME_EPOCHS]
-													: Axis.TYPE_DEFAULT_EPOCHS;
+		this._staticParams[Axis.TYPE_NAME_EPOCHS] =
+			params[Axis.TYPE_NAME_EPOCHS] !== undefined
+			? params[Axis.TYPE_NAME_EPOCHS]
+			: Axis.TYPE_DEFAULT_EPOCHS;
 
-		this._staticParams[Axis.TYPE_NAME_LAYERS] = params[Axis.TYPE_NAME_LAYERS] !== undefined
-													? params[Axis.TYPE_NAME_LAYERS]
-													: Axis.TYPE_DEFAULT_LAYERS;
+		this._staticParams[Axis.TYPE_NAME_LAYERS] =
+			params[Axis.TYPE_NAME_LAYERS] !== undefined
+			? params[Axis.TYPE_NAME_LAYERS]
+			: Axis.TYPE_DEFAULT_LAYERS;
 
-		this._staticParams[Axis.TYPE_NAME_NEURONS] = params[Axis.TYPE_NAME_NEURONS] !== undefined
-														? params[Axis.TYPE_NAME_NEURONS]
-														: Axis.TYPE_DEFAULT_NEURONS;
+		this._staticParams[Axis.TYPE_NAME_NEURONS] =
+			params[Axis.TYPE_NAME_NEURONS] !== undefined
+			? params[Axis.TYPE_NAME_NEURONS]
+			: Axis.TYPE_DEFAULT_NEURONS;
 
-		this._staticParams[Axis.TYPE_NAME_VALIDATION_SPLIT] = params[Axis.TYPE_NAME_VALIDATION_SPLIT] !== undefined
-																? params[Axis.TYPE_NAME_VALIDATION_SPLIT]
-																: Axis.TYPE_DEFAULT_VALIDATION_SPLIT;
+		this._staticParams[Axis.TYPE_NAME_VALIDATION_SPLIT] =
+			params[Axis.TYPE_NAME_VALIDATION_SPLIT] !== undefined
+			? params[Axis.TYPE_NAME_VALIDATION_SPLIT]
+			: Axis.TYPE_DEFAULT_VALIDATION_SPLIT;
 
 //vvvv WORK IN PROGRESS: Tack on the NOT-YET-SUPPORTED axes
 
@@ -129,64 +133,6 @@ class ModelStatics {
 //^^^^
 	}
 }
-
-
-ModelStatics.ERROR_TEXT_NON_NEGATIVE_INTEGER	= 'The value must be a non-negative integer.';
-ModelStatics.ERROR_TEXT_PARAM_UNKNOWN			= 'The parameter is not recognized.';
-ModelStatics.ERROR_TEXT_POSITIVE_INTEGER		= 'The value must a positive integer.';
-
-
-//NOTE: Exposing this static method, on the assumption outside scopes might want to validate model params.
-//
-//NOTE: There is an argument for moving this into Axis.
-ModelStatics.AttemptValidateParameter = (key, value, errorData) => {
-	console.assert(typeof errorData === 'object');
-	console.assert(errorData.message !== undefined);
-
-//NOTE: It's important to gracefully handle bad inputs here, with explanations and recommendations in the failure text.
-//		This has the potential to be a point-of-failure for new users ramping up on model config.
-
-	let errorSuffix = '';
-
-	switch (key) {
-		case Axis.TYPE_NAME_BATCH_SIZE:
-		case Axis.TYPE_NAME_EPOCHS:
-		case Axis.TYPE_NAME_NEURONS: {
-			if (Utils.CheckPositiveInteger(value)) {
-				return true;
-			}
-
-			errorSuffix = ModelStatics.ERROR_TEXT_POSITIVE_INTEGER;
-		}
-		break;
-
-		case Axis.TYPE_NAME_LAYERS: {
-			if (Utils.CheckNonNegativeInteger(value)) { // zero is allowed
-				return true;
-			}
-
-			errorSuffix = ModelStatics.ERROR_TEXT_NON_NEGATIVE_INTEGER;
-		}
-		break;
-
-		case Axis.TYPE_NAME_VALIDATION_SPLIT: {
-			if (Utils.CheckFloat0to1Exclusive(value)) { // zero and one are not allowed; they disable TF validation
-				return true;
-			}
-
-			errorSuffix = 'coming soon 32'//ModelStatics.ERROR_TEXT_NON_NEGATIVE_INTEGER;
-		}
-		break;
-
-		default: {
-			errorSuffix = ModelStatics.ERROR_TEXT_PARAM_UNKNOWN;
-		}
-	}
-
-	errorData.message = '"' + key + '" is not valid. ' + errorSuffix;
-
-	return false;
-};
 
 
 Object.freeze(ModelStatics);


### PR DESCRIPTION
- Move static validation routine from ModelStatics to Axis.
- Add a validation routine for Axis progressions (specifically
their int/float types).
- Run validation on bounds and progression in the Axis c'tor.
- Improve error reporting on this validation failures.