### PR TITLE
Update node native libs to ESM import

### DIFF
--- a/src/lib/FileIO.ts
+++ b/src/lib/FileIO.ts
@@ -1,8 +1,15 @@
 'use strict';
 
 
-const FS_PROMISES = require('fs/promises');
-const PATH_LIB = require('path');
+import * as FS_PROMISES from 'fs/promises';
+import * as PATH_LIB from 'path';
+
+
+//NOTE: Not yet ready to move this one to ESM, only because I don't want to bring in added
+//		module variability until the bundled package is ready. Stay tuned.
+//
+//		"This module can only be referenced with ECMAScript imports/exports by turning on
+//		the 'esModuleInterop' flag and referencing its default export.ts(2497)"
 const SLASH = require('slash');
 
 

--- a/src/lib/GridOptions.ts
+++ b/src/lib/GridOptions.ts
@@ -4,6 +4,9 @@
 import * as Types from '../ts_types/common';
 
 
+import * as FS from 'fs';
+
+
 import { Utils } from './Utils';
 
 
@@ -98,8 +101,6 @@ class GridOptions {
 					}
 					else {
 						// confirm this is a valid path of an existing directory (not a file)
-
-						const FS = require('fs');
 
 //TODO: Move these to FileIO (or FileIOSync).
 //TODO: (low-pri) Have that lib create the directory, if it doesn't exist ... maybe.

--- a/task list.txt
+++ b/task list.txt
@@ -1,4 +1,4 @@
-2020 11 17
+2020 11 24
 
 
 BUGS
@@ -11,16 +11,22 @@ This isn't catching the 0.3 cases, but it should, since bounds are inclusive:
 
 TODO
 TS conversion:
-	- full require() pass
-	- full 'ANY' pass
-	- full 'AS' pass
+	~ full require() pass
+		~ ONE EXCEPTION: The 'slash' lib wants extra tech for ESM; shelved as low-pri
+
 	- export a completely minified, bundled, whatever'd NPM-ready package
+
+	- project upgrades
+		- Lint
+		- TS
+		- Travis(?)
+		- JSDOC
+		- public Git
+		- NPM
 
 Break out a core object in (or from) ModelParams, with the literal TF types for each param; drop the dynamic list
 
 Write the CSVSource interface // This may be much better held until after TS.
-
-Project upgrades; Lint, TS, Travis(?), JSDOC, public Git, NPM
 
 Expose more behavior via optional callbacks
 	Custom models


### PR DESCRIPTION
- Note that this leaves one lib ('slash') as CommonJS, because it
needs the esModuleInterop flag, which I'm not ready to involve just yet.